### PR TITLE
Use multiple processes to parse rawdatadir to tmpfile

### DIFF
--- a/src/top_open_subtitles_sentences.py
+++ b/src/top_open_subtitles_sentences.py
@@ -1,7 +1,9 @@
 # Build the top-open-subtitles-sentences repository
 
+from concurrent.futures import ProcessPoolExecutor
 import os
 import shutil
+import sys
 import time
 import zipfile
 import gzip
@@ -224,7 +226,8 @@ def download_data_file(url, basedatadir, langcode):
 
 
 def parse_rawdatadir_to_tmpfile(langcode, rawdatadir, tmpfile,
-                                year_min, year_max):
+                                year_min, year_max):  
+    start = time.perf_counter()
     print("Parsing data:")
     if os.path.exists(tmpfile):
         os.remove(tmpfile)
@@ -236,41 +239,47 @@ def parse_rawdatadir_to_tmpfile(langcode, rawdatadir, tmpfile,
     n_matching_original = 0
     yeardatadir = os.path.join(rawdatadir, f"OpenSubtitles/raw/{langcode}")
     fout = open(tmpfile, 'a', encoding='utf-8')
-    for ydir in os.listdir(yeardatadir):
-        if int(ydir) < year_min or int(ydir) > year_max:
-            continue
-
-        print(f"   {ydir}")
-        outtext = ""
-        for mdir in os.listdir(os.path.join(yeardatadir, ydir)):
-            mdirfull = os.path.join(yeardatadir, ydir, mdir)
-            if not os.path.isdir(mdirfull):
+    
+    with ProcessPoolExecutor(max_workers=6) as executor:
+        for ydir in os.listdir(yeardatadir):
+            if int(ydir) < year_min or int(ydir) > year_max:
                 continue
-            if one_subtitle_per_movie:
-                # sort to make deterministic and take last
-                fname = sorted([f for f in os.listdir(mdirfull)
-                                if not f.startswith('.')])[-1]
-                fpathfull = os.path.join(yeardatadir, ydir,
-                                            mdir, fname)
-                n_subfiles += 1
-                outtext += text_from_xmlfile(fpathfull)
-            else:
-                for fname in os.listdir(mdirfull):
-                    if fname.startswith('.'):
-                        continue
+
+            print(f"   {ydir}")
+            xml_files = []
+            for mdir in os.listdir(os.path.join(yeardatadir, ydir)):
+                mdirfull = os.path.join(yeardatadir, ydir, mdir)
+                if not os.path.isdir(mdirfull):
+                    continue
+                if one_subtitle_per_movie:
+                    # sort to make deterministic and take last
+                    fname = sorted([f for f in os.listdir(mdirfull)
+                                    if not f.startswith('.')])[-1]
                     fpathfull = os.path.join(yeardatadir, ydir,
                                                 mdir, fname)
                     n_subfiles += 1
-                    if original_language_only:
-                        if check_if_original(fpathfull,
-                                                langcode):
-                            n_matching_original += 1
-                            outtext += text_from_xmlfile(fpathfull)
-                    else:
-                        outtext += text_from_xmlfile(fpathfull)
-        fout.write(outtext)
+                    xml_files.append(fpathfull)
+                else:
+                    for fname in os.listdir(mdirfull):
+                        if fname.startswith('.'):
+                            continue
+                        fpathfull = os.path.join(yeardatadir, ydir,
+                                                    mdir, fname)
+                        n_subfiles += 1
+                        if original_language_only:
+                            if check_if_original(fpathfull,
+                                                    langcode):
+                                n_matching_original += 1
+                                xml_files.append(fpathfull)
+                        else:
+                            xml_files.append(fpathfull)
+                    
+            y_text = list(executor.map(text_from_xmlfile, xml_files))                    
+            fout.write("".join(y_text))
+
     fout.close()
-    print(f"   files parsed: {n_subfiles}")
+    parse_time = time.perf_counter() - start
+    print(f"   {n_subfiles} files parsed in {parse_time:.1f} seconds")
     if original_language_only:
         print(f"   {n_original_info/n_subfiles:.0%} with original info")
         print(f"   {n_matching_original/n_subfiles:.0%} "


### PR DESCRIPTION
In this PR, parse_rawdatadir_to_tmpfile now creates a list of xml files to parse for every year and then does:
```python
y_text = list(executor.map(text_from_xmlfile, xml_files))  
fout.write("".join(y_text))
```
where executor comes from:
```python
with ProcessPoolExecutor(max_workers=6) as executor:
```

With 'nl' and year_max = 2005, I got from __426s__ to __15s__. 

The behavior of going through the years sequentially is still preserved. 

I also tested just using threads, but multiple processes was even faster when I tested it. Increasing max_workers higher than 6 didn't do much, so I guess 6 is enough to step over the IO bottleneck in a significant way.