### PR TITLE
Fix Chinese tokenization.

### DIFF
--- a/src/top_open_subtitles_sentences.py
+++ b/src/top_open_subtitles_sentences.py
@@ -317,10 +317,10 @@ def text_from_xmlfile(infile):
     return ''.join(text_lines)
 
 
-def batched(iterable, n: int):
+def batched(iterable, batch_size: int):
     it = iter(iterable)
     while True:
-        batch = tuple(itertools.islice(it, n))
+        batch = tuple(itertools.islice(it, batch_size))
         if not batch:
             return
         yield batch
@@ -584,7 +584,7 @@ def tokenize_lines(lines: list, langcode: str, get_spacy_pipeline):
 
 def tokenize_lines_mp(lines, langcode, executor: ProcessPoolExecutor):
 
-    lines_batched = batched(lines, int(lines_per_chunk/n_process))
+    lines_batched = batched(lines, int(lines_per_chunk/(n_process*25)))
     tokenize_func = partial(tokenize_lines, langcode=langcode, get_spacy_pipeline=get_spacy_pipeline)
     dt = itertools.chain.from_iterable(executor.map(tokenize_func, lines_batched))  
     return itertools.chain.from_iterable(dt)

--- a/src/top_open_subtitles_sentences.py
+++ b/src/top_open_subtitles_sentences.py
@@ -304,15 +304,15 @@ def check_if_original(infile, langcode):
 
 
 def text_from_xmlfile(infile):
-    fin = open(infile, 'r', encoding='utf-8')
-    text = ""    
-    for line in fin.readlines():
-        # xml and text content are on separate lines
-        if line.startswith('<') or line.startswith(' '):
-            continue
-        text += line.strip(linestrip_pattern) + "\n"
-    fin.close()
-    return text
+    text_lines = []
+    with open(infile, 'r', encoding='utf-8') as fin:
+        for line in fin:
+            if line.startswith(('<', ' ')):
+                continue
+            stripped_line = line.strip(linestrip_pattern)
+            if stripped_line:
+                text_lines.append(stripped_line + "\n")
+    return ''.join(text_lines)
 
 
 def parsedfile_to_top_sentences(parsedfile, outfile,


### PR DESCRIPTION
This fixes the Chinese tokenization issue and implements multiprocessing for the tokenization of lines in `parsedfile_to_top_words()`.

Other changes also relate to performance (except for the `check_line_count()` function 😄)

Note: 
- the `join_to_min_length()` function makes the lines longer. It might look a bit weird, but it does improve performance (15-20%).  
- I originally used Spacy's own support for multiprocessing (`nlp.pipe(big_lines, n_process=spacy_n_process`, see diff of last commit), but the performance increase wasn't very impressive. It also sometimes caused OS related errors (windows)
- in `get_spacy_pipeline()` you can enable the loading of model "zh_core_web_sm" or add any other model, if needed.